### PR TITLE
Dynamic node import

### DIFF
--- a/PYTHON/WATCH/watch.py
+++ b/PYTHON/WATCH/watch.py
@@ -8,8 +8,6 @@ import warnings
 
 import matplotlib.cbook
 import networkx as nx
-import yaml
-
 from flojoy import get_next_directions, get_next_nodes
 
 warnings.filterwarnings("ignore", category=matplotlib.cbook.mplDeprecation)
@@ -17,15 +15,11 @@ warnings.filterwarnings("ignore", category=matplotlib.cbook.mplDeprecation)
 dir_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.abspath(os.path.join(dir_path, os.pardir)))
 
-from nodes import *
 from services.job_service import JobService
+from utils.dynamic_module_import import get_module_func
 from utils.topology import Topology
 
-
 ENV_CI = 'CI'
-stream = open('STATUS_CODES.yml', 'r', encoding='utf-8')
-STATUS_CODES = yaml.safe_load(stream)
-
 
 class FlowScheduler:
     def __init__(self, **kwargs) -> None:
@@ -116,7 +110,7 @@ class FlowScheduler:
             nodes_to_add += [node_id for node_id in next_nodes]
 
         if len(nodes_to_add) > 0:
-            print(F"  + adding nodes to graph:", [self.topology.get_label(n_id, original=True) for n_id in nodes_to_add])
+            print("  + adding nodes to graph:", [self.topology.get_label(n_id, original=True) for n_id in nodes_to_add])
 
         for node_id in nodes_to_add:
             self.topology.restart(node_id)
@@ -126,14 +120,11 @@ class FlowScheduler:
         node = self.nx_graph.nodes[job_id]
         cmd = node['cmd']
         cmd_mock = node['cmd'] + '_MOCK'
-        func = getattr(globals()[cmd], cmd)
-
-        # when running in CI environment use the mock function instead if its defined
+        func = get_module_func(cmd, cmd)
         if self.is_ci:
             try:
-                func = getattr(globals()[cmd], cmd_mock)
-                print( ' running the mock version:', cmd_mock)
-            except:
+                func = get_module_func(cmd, cmd_mock)
+            except Exception:
                 pass
 
         dependencies = self.topology.get_job_dependencies(job_id, original=True)
@@ -206,11 +197,11 @@ def reactflow_to_networkx(elems, edges):
 
     for i in range(len(edges)):
         e = edges[i]
-        id = e['id']
+        _id = e['id']
         u = e['source']
         v = e['target']
         label = e['sourceHandle']
-        nx_graph.add_edge(u, v, label=label, id=id)
+        nx_graph.add_edge(u, v, label=label, id=_id)
 
     nx.draw(nx_graph, with_labels=True)
 

--- a/PYTHON/services/job_service.py
+++ b/PYTHON/services/job_service.py
@@ -1,13 +1,11 @@
-import traceback
-
 from common.CONSTANTS import (KEY_ALL_JOBEST_IDS, KEY_FLOJOY_WATCH_JOBS,
                               KEY_RQ_WORKER_JOBS)
 from dao.redis_dao import RedisDao
+from node_sdk.small_memory import SmallMemory
 from rq import Queue
 from rq.command import send_stop_job_command
 from rq.exceptions import InvalidJobOperation, NoSuchJobError
 from rq.job import Job, NoSuchJobError
-from node_sdk.small_memory import SmallMemory
 
 
 def report_failure(job, connection, type, value, traceback):
@@ -82,14 +80,12 @@ class JobService():
         
         job = self.queue.enqueue(func,
                 job_timeout='15m',
-                # timeout='300s',
                 on_failure=report_failure,
                 job_id=iteration_id,
                 kwargs={'ctrls': ctrls,
                         'previous_job_ids': input_job_ids,
                         'jobset_id': jobset_id, 'node_id': job_id, 'job_id': iteration_id},
                 depends_on=previous_job_ids
-                # result_ttl=500
             )
         self.add_job(iteration_id, jobset_id)
 

--- a/PYTHON/utils/dynamic_module_import.py
+++ b/PYTHON/utils/dynamic_module_import.py
@@ -1,0 +1,22 @@
+import os
+from importlib import import_module
+
+nodes_dir = "PYTHON/nodes"
+
+def get_module_func(file_name:str, func_name:str):
+
+  file_path = None
+  for root, dirs, files in os.walk(nodes_dir):
+      for file in files:
+          if file == f"{file_name}.py":
+              file_path = os.path.join(root, file_name).replace('/', '.').replace('\\', '.').replace('PYTHON.', '')
+              break
+      if file_path is not None:
+          break
+
+  if file_path is not None:
+      module = import_module(file_path)
+      return getattr(module, func_name)
+
+  else:
+      print(f"File {file_name} not found in subdirectories of {nodes_dir}")

--- a/djangoServer/views.py
+++ b/djangoServer/views.py
@@ -1,19 +1,21 @@
+import json
 import os
 import sys
-import json
-import yaml
-from PYTHON.WATCH import *
-from datetime import datetime
-from django.shortcuts import render
-from asgiref.sync import async_to_sync
-from rest_framework.response import Response
-from channels.layers import get_channel_layer
-from rest_framework.decorators import api_view
-from PYTHON.services.job_service import JobService
 import time
+from datetime import datetime
+
+import yaml
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, dir_path)
+
+from PYTHON.WATCH.watch import run
+from PYTHON.services.job_service import JobService
 
 job_service = JobService('flojoy-watch')
 q = job_service.queue
@@ -74,12 +76,10 @@ def run_flow_chart(request):
     }
     send_msg_to_socket(msg=msg)
 
-    func = getattr(globals()['watch'], 'run')
-    print('func:', func)
     scheduler_job_id = f'{jobset_id}_{datetime.now()}'
     job_service.add_flojoy_watch_job_id(scheduler_job_id)
 
-    q.enqueue(func,
+    q.enqueue(run,
               on_failure=report_failure,
               job_id=scheduler_job_id,
               kwargs={'fc': fc,


### PR DESCRIPTION
Feature:
- Import node functions dynamically only before enqueuing to RQ Worker instead of importing them all using '*'.
- Now there is no need to import node functions or add them to `__init__.py` file.
- There will be no error if any node-specific Python dependency is missing except that node is added to the flow chart and clicked `Play`.