### PR TITLE
Fix saving on non-chrome browsers and disable Save As when not supported

### DIFF
--- a/cypress/e2e/saving_apps.spec.cy.ts
+++ b/cypress/e2e/saving_apps.spec.cy.ts
@@ -15,7 +15,7 @@ describe("Saving Default App", () => {
     );
     cy.get(`[data-cy="dropdown-wrapper"]`)
       .click()
-      .get(`[data-cy="btn-save"]`)
+      .get(`[data-cy="btn-saveas"]`)
       .click();
     cy.get("@showSaveFilePicker")
       .should("have.been.calledOnce")

--- a/src/feature/common/dropdown/dropdown.css
+++ b/src/feature/common/dropdown/dropdown.css
@@ -39,10 +39,10 @@
 .dropdown__container.light > button {
   color: #000;
 }
-.dropdown__container.light > button:hover {
+.dropdown__container.light > button:not(.disabled):hover {
   background-color: #d9d9d9;
 }
-.dropdown__container > button:hover {
+.dropdown__container > button:not(.disabled):hover {
   background-color: #94f4fc;
   color: black;
 }

--- a/src/feature/flow_chart_panel/views/ControlBar.tsx
+++ b/src/feature/flow_chart_panel/views/ControlBar.tsx
@@ -30,8 +30,14 @@ const Controls: FC<ControlsProps> = ({
   const { socketId, setProgramResults, serverStatus } = states!;
   const [isKeyboardShortcutOpen, setIskeyboardShortcutOpen] = useState(false);
 
-  const { isEditMode, setIsEditMode, rfInstance, openFileSelector, saveFile } =
-    useFlowChartState();
+  const {
+    isEditMode,
+    setIsEditMode,
+    rfInstance,
+    openFileSelector,
+    saveFile,
+    saveFileAs,
+  } = useFlowChartState();
   const onSave = async () => {
     if (rfInstance && rfInstance.nodes.length > 0) {
       saveFlowChartToLocalStorage(rfInstance);
@@ -59,6 +65,8 @@ const Controls: FC<ControlsProps> = ({
   const isPlayBtnDisabled = () =>
     serverStatus === IServerStatus.CONNECTING ||
     serverStatus === IServerStatus.OFFLINE;
+
+  const saveAsDisabled = !("showSaveFilePicker" in window);
 
   return (
     <div className="save__controls">
@@ -123,8 +131,20 @@ const Controls: FC<ControlsProps> = ({
             style={{
               display: "flex",
               justifyContent: "space-between",
+              ...(saveAsDisabled && {
+                cursor: "not-allowed",
+                opacity: 0.5,
+              }),
             }}
-            onClick={saveFile}
+            className={saveAsDisabled ? "disabled" : ""}
+            disabled={saveAsDisabled}
+            aria-label="Save As"
+            title={
+              saveAsDisabled
+                ? "Save As is not supported in this browser, sorry!"
+                : ""
+            }
+            onClick={saveFileAs}
           >
             <span>Save As</span>
             <small>Ctrl + s</small>

--- a/src/hooks/useFlowChartState.ts
+++ b/src/hooks/useFlowChartState.ts
@@ -127,17 +127,39 @@ export function useFlowChartState() {
     });
   }, [filesContent, loadFlowExportObject, setCtrlsManifest, setGridLayout]);
 
+  const getFileBlob = (rf: ReactFlowJsonObject<ElementsData>) => {
+    const fileContent = {
+      rfInstance,
+      ctrlsManifest,
+    };
+    const fileContentJsonString = JSON.stringify(fileContent, undefined, 4);
+
+    return new Blob([fileContentJsonString], {
+      type: "text/plain;charset=utf-8",
+    });
+  };
+
   const saveFile = async () => {
     if (rfInstance) {
-      const fileContent = {
-        rfInstance,
-        ctrlsManifest,
-      };
-      const fileContentJsonString = JSON.stringify(fileContent, undefined, 4);
+      const blob = getFileBlob(rfInstance);
 
-      const blob = new Blob([fileContentJsonString], {
-        type: "text/plain;charset=utf-8",
-      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "flojoy.txt";
+
+      document.body.appendChild(link);
+      link.click();
+
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  const saveFileAs = async () => {
+    if (rfInstance) {
+      const blob = getFileBlob(rfInstance);
+
       const handle = await (window as any).showSaveFilePicker({
         suggestedName: "flojoy.txt",
         types: [
@@ -201,6 +223,7 @@ export function useFlowChartState() {
     loadFlowExportObject,
     openFileSelector,
     saveFile,
+    saveFileAs,
     isEditMode,
     setIsEditMode,
     gridLayout,


### PR DESCRIPTION
Currently opening a save file picker only works on Chrome >= 86, so on non chrome based browsers the button will just be disabled.