### PR TITLE
update plotly viz nodes to accept dataframe

### DIFF
--- a/src/configs/NodeConfigs.ts
+++ b/src/configs/NodeConfigs.ts
@@ -9,7 +9,7 @@ export const nodeConfigs = {
   default: DefaultNode,
   ARITHMETIC: ArithmeticNode,
   SIMULATION: SimulationNode,
-  VISOR: VisorNode,
+  PLOTLY_VISOR: VisorNode,
   CONDITIONAL: ConditionalNode,
   TERMINATOR: TerminatorNode,
   SAMPLE_IMAGE: DefaultNode,

--- a/src/feature/flow_chart_panel/views/NodeModal.tsx
+++ b/src/feature/flow_chart_panel/views/NodeModal.tsx
@@ -74,7 +74,7 @@ const NodeModal = ({
               data={nd.result.default_fig.data}
               layout={
                 "layout" in nd.result.default_fig
-                  ? Object.assign({}, nd.result.default_fig.layout)
+                  ? Object.assign({}, defaultLayout)
                   : Object.assign({}, { title: `${nd.cmd}` }, defaultLayout)
               }
               useResizeHandler


### PR DESCRIPTION
Updated plot visual nodes to accept `dataframe` type of `DataContainer` class.

![Screenshot from 2023-05-13 02-58-27](https://github.com/flojoy-io/studio/assets/86223939/4f34f74c-e3e2-4ec9-87ba-13e3cdba6cdb)
