### PR TITLE
update delete node keystroke

### DIFF
--- a/src/__tests__/feature/flow_chart_panel/views/__snapshots__/KeyboardShortcutModal.test.tsx.snap
+++ b/src/__tests__/feature/flow_chart_panel/views/__snapshots__/KeyboardShortcutModal.test.tsx.snap
@@ -373,7 +373,7 @@ exports[`KeyboardShortcutModal renders correctly when isOpen is true 1`] = `
           <span
             class="kbs__cmd__key"
           >
-            ⌘ D
+            Backspace
           </span>
         </div>
       </div>

--- a/src/feature/flow_chart_panel/views/KeyboardShortcutModal.tsx
+++ b/src/feature/flow_chart_panel/views/KeyboardShortcutModal.tsx
@@ -176,7 +176,7 @@ const keyboardShortcuts = [
     command: "Delete",
     platforms: {
       windows: "Ctrl D",
-      macOs: "⌘ D",
+      macOs: "Backspace",
     },
   },
 ];


### PR DESCRIPTION
For the record: I am working on a ThinkPad IBM / Ubuntu / and running the studio in my browser. 

When I try to use Ctrl-D to delete a node as directed in the menu, it doesn't work. Backspace does work though. This change reflects that.