### PR TITLE
Trigger test PR workflow

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -1,0 +1,44 @@
+name: Trigger test PR workflow
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  pull_request_target:
+    types:
+      - closed
+
+
+env:
+  PROJECT_OWNER: flojoy-io
+  PROJECT_REPO: rc
+  PROJECT_WORKFLOW_ID: terraform-test-env.yml
+  PROJECT_TOKEN: ${{ secrets.ACCESS_TOKEN_FLOJOY_RC }}
+
+jobs:
+  trigger_workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Print Parameters
+        run: |
+          echo "GitHub Event Name: ${{ github.event_name}}"
+          echo "GitHub Head Ref: ${{ github.head_ref }}"
+          echo "GitHub Event Pull Request Number: ${{ github.event.pull_request.number }}"
+          echo "Context Issue Number: ${{ github.event.pull_request.number}}"
+          echo "Context Repo Owner: ${{ github.repository_owner }}"
+          echo "Context Repo Repo: ${{ github.repository }}"
+          echo "GitHub Event Pull Request Merged: ${{ github.event.pull_request.merged }}"
+          echo "GitHub Event Action: ${{ github.event.action }}"
+
+      - name: Trigger test PR
+        run: |
+          curl -X POST https://api.github.com/repos/${{ env.PROJECT_OWNER }}/${{ env.PROJECT_REPO }}/actions/workflows/${{ env.PROJECT_WORKFLOW_ID }}/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ env.PROJECT_TOKEN }} \
+          --data '{"ref":"main", "inputs":{"github_event_name":"${{ github.event_name }}", "github_head_ref": "${{ github.head_ref }}", "github_event_pull_request_number": "${{ github.event.pull_request.number }}", "context_issue_number": "${{ github.event.pull_request.number }}", "context_repo_owner": "${{ github.repository_owner }}", "context_repo_repo": "${{ github.repository }}", "github_event_pull_request_merged": "${{ github.event.pull_request.merged }}", "github_event_action": "${{ github.event.action }}"}}'
+      - uses: actions/checkout@v3 


### PR DESCRIPTION
New Github action to trigger a workflow.

When PR is opened:

- Create VM instance.
- Create DNS for the instance.
- Clone the branch.
- Start Flojoy Studio.
- Expose the build for testing.
- Add the URL as a comment to the PR.

When PR is closed:

- Terminate the VM instance.
- Deregister the DNS name.
- Delete tfstate.

Freatures: 

- The VM is stopped after 1 hour (to save cost).
- A webservice to start the VM again if needed (for 1 hour).
- Flojoy Studio can work using a public IP or domain name.

 