### PR TITLE
Debugging python nodes in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ worker-manager/node_modules
 
 /**/.idea/*
 .vscode/*
+!.vscode/launch.json
 
 src/data/*.json
 src/feature/flow_chart_panel/manifest/pythonFunctions.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Attach",
+      "type": "python",
+      "request": "attach",
+      "justMyCode": false,
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      }
+    }
+  ]
+}

--- a/PYTHON/worker.py
+++ b/PYTHON/worker.py
@@ -1,0 +1,34 @@
+from redis import Redis
+from rq import Queue, Worker
+import os
+
+import debugpy
+
+from dao.redis_dao import RedisDao
+
+DEFAULT_PORT = 5678
+
+
+def debugger():
+    print("Checking whether to run debugger")
+    if os.environ.get("DEBUG", None) == "True":
+        port = os.environ.get("DEBUG_PORT", DEFAULT_PORT)
+        try:
+            endpoint = debugpy.listen(port)
+            print(f"Started debugger on {endpoint}")
+            is_wait = os.environ.get("DEBUG_WAIT", False) == "True"
+            if is_wait:
+                print(f"Waiting for debugger to attach on port: {port}")
+                debugpy.wait_for_client()
+        except:
+            print(f"Failed to start debugging or its already running")
+    else:
+        print(f"Debugging is off")
+
+
+debugger()
+
+queue = Queue("flojoy", connection=RedisDao().r)
+
+worker = Worker([queue], connection=RedisDao().r, name="flojoy")
+worker.work()

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "backend": "python3 manage.py runserver",
     "bundle-plotly": "cd node_modules/plotly.js && npm i && npm run custom-bundle -- --traces scatter,scatter3d,surface,table,histogram,image,bar,indicator",
     "rq-watch": "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES rq worker flojoy-watch",
-    "rq-flojoy": "cd PYTHON && OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES rq worker flojoy",
+    "rq-flojoy": "cd PYTHON && OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python worker.py",
     "start-project": "concurrently --prefix \"[{time}-{name}]\" -n \"React,Django,RQ-watch,RQ-flojoy\" -c auto  \"npm:start\" \"npm:backend\" \"npm:rq-watch\" \"npm:rq-flojoy\"",
     "start-project:win": "concurrently -n \"React,Django,RQ-watch,RQ-flojoy\" -c auto  \"npm:start\" \"npm:backend\" \"rqworker.exe -w rq_win.WindowsWorker flojoy-watch\" \"cd PYTHON && rqworker.exe -w rq_win.WindowsWorker flojoy\"",
     "start-project:ci": "CI=true concurrently --prefix \"[{time}-{name}]\" -n \"React,Django,RQ-watch,RQ-flojoy\" -c auto  \"npm:start\" \"npm:backend\" \"npm:rq-watch\" \"npm:rq-flojoy\"",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pytest==7.1.3
 black==23.3.0
 sentry-sdk[django]==1.24.0
 pytest-cov==4.1.0
+debugpy


### PR DESCRIPTION
### What problem this PR solves?
Debugging nodes is hard right now. Currently we rely on console printing the values which is very tedious. Also with all the commands now run in a single tab, we don't see printouts from node functions reliably. This PR adds debugging support for IDE. It is tested with vscode for now. It might work with other IDEs that supports debugging through [debugpy].(https://github.com/microsoft/debugpy)

### What is the implemented solution?
Used the  [debugpy](https://github.com/microsoft/debugpy) library to support debugging in vscode. This PR adds a separate rq worker implementation which starts the debugger. The debugger can be configured through environment variables. It currently supports three variables.
1. `DEBUG`: This turns debugging mode on for node python functions. Acceptable values are `True`, `False`. By default debugging is disabled.
1. `DEBUG_PORT`: The port where the debugger should listen to. Accepts a valid port number. Default is `5678`.
1. `DEBUG_WAIT`: Whether the debugger should wait for a client (vscode) to connect. Acceptable values are `True`, `False`. Default is false.

To debug, following steps are required:
1. Run flojoy with the `DEBUG` env variable set, for example:
```
DEBUG=True bash flojoy
```
2. In vscode, open the debug tab, run `Start Debugging`

<img width="423" alt="Screenshot 2023-06-10 at 1 19 54 PM" src="https://github.com/flojoy-io/studio/assets/100451944/ee864ccd-f293-49d6-a61a-6bd12320c60a">

3. Set breakpoints where you want to. You can set breakpoint inside pip modules as well (e.g. `@flojoy` decorator)

<img width="398" alt="Screenshot 2023-06-10 at 1 21 14 PM" src="https://github.com/flojoy-io/studio/assets/100451944/41678a74-34a5-459e-8723-b1d9c7cb5899">

That's it. Now as you run the flow chart in frontend, VS code will steal focus to let you debug.

### How was this change tested?
Tested with the default example app in local machine following the above steps.
