### PR TITLE
Add Live test on Reflect.run

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -14,6 +14,8 @@ env:
   PROJECT_REPO: rc
   PROJECT_WORKFLOW_ID: terraform-test-env.yml
   PROJECT_TOKEN: ${{ secrets.ACCESS_TOKEN_FLOJOY_RC }}
+  REFLECT_SUITE: flojoy-live-test
+  REFLECT_TOKEN: ${{ secrets.REFLECT_TOKEN }}
 
 jobs:
   trigger_workflow:
@@ -35,6 +37,7 @@ jobs:
           echo "GitHub Event Action: ${{ github.event.action }}"
 
       - name: Trigger test PR
+        if: github.event.action == 'opened'
         id: trigger_pr
         run: |
           curl -X POST https://api.github.com/repos/${{ env.PROJECT_OWNER }}/${{ env.PROJECT_REPO }}/actions/workflows/${{ env.PROJECT_WORKFLOW_ID }}/dispatches \
@@ -42,6 +45,7 @@ jobs:
           -u ${{ env.PROJECT_TOKEN }} \
           --data '{"ref":"main", "inputs":{"github_event_name":"${{ github.event_name }}", "github_head_ref": "${{ github.head_ref }}", "github_event_pull_request_number": "${{ github.event.pull_request.number }}", "context_issue_number": "${{ github.event.pull_request.number }}", "context_repo_owner": "${{ github.repository_owner }}", "context_repo_repo": "${{ github.repository }}", "github_event_pull_request_merged": "${{ github.event.pull_request.merged }}", "github_event_action": "${{ github.event.action }}"}}'
       - uses: actions/checkout@v3
+
       - name: Wait for 10m
         run: sleep 10m
 
@@ -103,3 +107,45 @@ jobs:
             echo "Test failed on Linux."
             exit1
           fi
+
+      - name: Windows live test on Reflect.run 
+        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        run: |
+          curl --location 'https://api.reflect.run/v1/suites/${{ env.REFLECT_SUITE }}/executions' \
+          --header 'Content-Type: text/plain' \
+          --header 'X-API-KEY: ${{ secrets.REFLECT_TOKEN }}' \
+          --data '{
+            "browser": "Chrome",
+            "overrides": {
+              "hostnames": [{
+                "original": "windows01.flojoy-test.com:3000",
+                "replacement": "${{ steps.extract-ip-port.outputs.domain_windows }}:3000"
+              }]
+            },
+            "gitHub": {
+                "owner": "${{ github.repository_owner }}",
+                "repo": "${{ github.event.repository.name}}",
+                "sha": "${{ github.event.pull_request.head.sha }}"
+            }
+          }'
+
+      - name: Linux live test on Reflect.run 
+        if: github.event.action == 'opened' || github.event.action == 'synchronize'
+        run: |
+          curl --location 'https://api.reflect.run/v1/suites/${{ env.REFLECT_SUITE }}/executions' \
+          --header 'Content-Type: text/plain' \
+          --header 'X-API-KEY: ${{ secrets.REFLECT_TOKEN }}' \
+          --data '{
+            "browser": "Chrome",
+            "overrides": {
+              "hostnames": [{
+                "original": "windows01.flojoy-test.com:3000",
+                "replacement": "${{ steps.extract-ip-port.outputs.domain_linux }}:3000"
+              }]
+            },
+            "gitHub": {
+                "owner": "${{ github.repository_owner }}",
+                "repo": "${{ github.event.repository.name}}",
+                "sha": "${{ github.event.pull_request.head.sha }}"
+            }
+          }'


### PR DESCRIPTION
Added Features:

- Add live test for Windows and Linux on reflect.run
- The creation of instances triggered exclusively when a pull request is opened.