### PR TITLE
#529 pass to an enqueued job the input names its previous jobs connects to

### DIFF
--- a/PYTHON/services/job_service.py
+++ b/PYTHON/services/job_service.py
@@ -83,10 +83,8 @@ class JobService:
         iteration_id,
         ctrls,
         previous_job_ids,
-        input_job_ids=None,
+        previous_jobs,
     ):
-        input_job_ids = input_job_ids if input_job_ids is not None else previous_job_ids
-
         if Job.exists(job_id, self.redis_dao.r):
             job = Job.fetch(job_id, connection=self.redis_dao.r)
             job.delete()
@@ -98,12 +96,13 @@ class JobService:
             job_id=iteration_id,
             kwargs={
                 "ctrls": ctrls,
-                "previous_job_ids": input_job_ids,
+                "previous_job_ids": previous_job_ids,
+                "previous_jobs": previous_jobs,
                 "jobset_id": jobset_id,
                 "node_id": job_id,
                 "job_id": iteration_id,
             },
-            depends_on=previous_job_ids,
+            depends_on=[],
         )
         self.add_job(iteration_id, jobset_id)
 

--- a/PYTHON/utils/topology.py
+++ b/PYTHON/utils/topology.py
@@ -108,12 +108,35 @@ class Topology:
             print(" + add", self.get_label(job_id), "in jobq")
             self.jobq.append(job_id)
 
-    def get_job_dependencies(self, job_id, original=False):
+    def get_job_dependencies(self, job_id, original=False) -> list[str]:
         graph = self.get_graph(original)
         try:
             return list(graph.predecessors(job_id))
         except Exception:
             return []
+
+    def get_job_dependencies_with_label(
+        self, job_id: str, original: bool = True
+    ) -> list[dict[str, str]]:
+        graph = self.get_graph(original)
+        try:
+            return [
+                {
+                    "job_id": prev_job_id,
+                    "input_name": self.get_input_name(prev_job_id, job_id, original),
+                }
+                for prev_job_id in list(graph.predecessors(job_id))
+            ]
+        except Exception:
+            return []
+
+    def get_input_name(
+        self, source_job_id: str, target_job_id: str, original: bool = False
+    ) -> str:
+        graph = self.get_graph(original)
+        edge_data = graph.get_edge_data(source_job_id, target_job_id)
+        label = "" if edge_data is None else edge_data.get("target_label", "")
+        return label
 
     def finished(self):
         print(


### PR DESCRIPTION
### Why is this change needed?
Currently a node receives its inputs as an array. It's been reported that the ordering of inputs do not stay fixed. We need a way for nodes to identify inputs by their name. 

This change sends to the `@flojoy` decorator the input names that a node's previous jobs connect to. 

See related PR https://github.com/flojoy-io/python/pull/40

### What is the solution implemented?
When enqueuing an rq job, the scheduler (`Watch.py`) now sends a dictionary of previous jobs where each job item contains the previous job id and the input name it connects to. Before this change the scheduler used to send only the previous job ids as a list.

It is backward compatible and can be merged independently. It still sends the previous job ids, in addition now sends a dictionary with previous jobs information.

### How was this change tested?
I ran the default app and checked that the `@flojoy` decorator now receives the input names. Here's a screenshot of a debugging session for the ADD node inspecting the `**kwargs` value of the `@flojoy` decorator. It shows that previous_jobs received the expected dictionary.

Here's a screenshot:
<img width="746" alt="Screenshot 2023-06-15 at 11 17 00 PM" src="https://github.com/flojoy-io/studio/assets/100451944/8cc77635-25ae-4702-aca3-51e7ccc8f892">



**Issue:** https://github.com/flojoy-io/studio/issues/529