### PR TITLE
Debugging scheduler (Watch.py) in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,23 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Python: Attach",
+      "name": "RQ Worker",
       "type": "python",
       "request": "attach",
       "justMyCode": false,
       "connect": {
         "host": "localhost",
         "port": 5678
+      }
+    },
+    {
+      "name": "RQ Watch",
+      "type": "python",
+      "request": "attach",
+      "justMyCode": false,
+      "connect": {
+        "host": "localhost",
+        "port": 5679
       }
     }
   ]

--- a/PYTHON/services/job_service.py
+++ b/PYTHON/services/job_service.py
@@ -1,4 +1,10 @@
-from PYTHON.common.CONSTANTS import (
+import os
+import sys
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.abspath(os.path.join(dir_path, os.pardir)))
+
+from common.CONSTANTS import (
     KEY_ALL_JOBEST_IDS,
     KEY_FLOJOY_WATCH_JOBS,
     KEY_RQ_WORKER_JOBS,

--- a/PYTHON/watch_worker.py
+++ b/PYTHON/watch_worker.py
@@ -1,0 +1,33 @@
+from rq import Queue, Worker
+import os
+
+import debugpy
+
+from dao.redis_dao import RedisDao
+
+DEFAULT_PORT = 5679
+
+
+def debugger():
+    print("Checking whether to run debugger for rq watch")
+    if os.environ.get("DEBUG", None) == "True":
+        port = os.environ.get("DEBUG_PORT", DEFAULT_PORT)
+        try:
+            endpoint = debugpy.listen(port)
+            print(f"Started debugger for rq watch on {endpoint}")
+            is_wait = os.environ.get("DEBUG_WAIT", False) == "True"
+            if is_wait:
+                print(f"Waiting for debugger for rq watch to attach on port: {port}")
+                debugpy.wait_for_client()
+        except:
+            print(f"Failed to start debugging for rq watch or its already running")
+    else:
+        print(f"Debugging for rq watch is off")
+
+
+debugger()
+
+queue = Queue("flojoy-watch", connection=RedisDao().r)
+
+worker = Worker([queue], connection=RedisDao().r, name="flojoy-watch")
+worker.work()

--- a/PYTHON/worker.py
+++ b/PYTHON/worker.py
@@ -1,4 +1,3 @@
-from redis import Redis
 from rq import Queue, Worker
 import os
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "open": "concurrently \"http-server -a localhost -p 3000\" \"open http://localhost:3000\"",
     "backend": "python3 manage.py runserver",
     "bundle-plotly": "cd node_modules/plotly.js && npm i && npm run custom-bundle -- --traces scatter,scatter3d,surface,table,histogram,image,bar,indicator",
-    "rq-watch": "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES rq worker flojoy-watch",
+    "rq-watch": "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python3 PYTHON/watch_worker.py",
     "rq-flojoy": "cd PYTHON && OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python3 worker.py",
     "start-project": "concurrently --prefix \"[{time}-{name}]\" -n \"React,Django,RQ-watch,RQ-flojoy\" -c auto  \"npm:start\" \"npm:backend\" \"npm:rq-watch\" \"npm:rq-flojoy\"",
     "start-project:win": "concurrently --prefix \"[{time}-{name}]\" -n \"React,Django,RQ-watch,RQ-flojoy\" -c auto  \"npm:start\" \"npm:backend\" \"rqworker.exe -w rq_win.WindowsWorker flojoy-watch\" \"cd PYTHON && rqworker.exe -w rq_win.WindowsWorker flojoy\"",

--- a/server/services/pre_job_service.py
+++ b/server/services/pre_job_service.py
@@ -3,8 +3,14 @@ import pkg_resources
 from datetime import datetime
 from ..utils.install_package import install_packages
 from ..utils.send_to_socket import send_msg_to_socket
-from PYTHON.services.job_service import JobService
-from PYTHON.WATCH.watch import run
+import os
+import sys
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.abspath(os.path.join(dir_path, os.pardir)))
+
+from services.job_service import JobService
+from WATCH.watch import run
 
 job_service = JobService("flojoy-watch")
 q = job_service.queue


### PR DESCRIPTION
### Why is this change needed?
Debugging scheduler (`Watch.py`) is hard right now. Currently we rely on console printing the values which is very tedious. Also with all the commands now run in a single tab, we don't see printouts from node functions reliably. This PR adds support to debug the scheduler within IDEs. It is tested with VS Code for now. It might work with other IDEs that supports debugging through [debugpy].(https://github.com/microsoft/debugpy)

### What is the implemented solution?
Used the  [debugpy](https://github.com/microsoft/debugpy) library to support debugging in VS Code. This PR adds a separate rq worker implementation for the scheduler. This worker starts the debugger. The debugger can be configured through environment variables. It currently supports three variables.
1. `DEBUG`: This turns debugging mode on. Acceptable values are `True`, `False`. By default debugging is disabled.
1. `DEBUG_PORT`: The port where the debugger should listen to. Accepts a valid port number. Default is `5679`.
1. `DEBUG_WAIT`: Whether the debugger should wait for a client (vscode) to connect. Acceptable values are `True`, `False`. Default is false.

To debug, following steps are required:
1. Run flojoy with the `DEBUG` env variable set, for example:
```
DEBUG=True bash flojoy
```
2. In VS Code, open the debug tab. You should now see two options for debugging (see screenshot below). Select `RQ Watch` and hit the play button next to it.

<img width="376" alt="Screenshot 2023-06-15 at 11 47 05 PM" src="https://github.com/flojoy-io/studio/assets/100451944/150d2357-06b3-437f-8343-149d73f87956">


3. Set breakpoints where you want to.

<img width="1710" alt="Screenshot 2023-06-15 at 11 33 37 PM" src="https://github.com/flojoy-io/studio/assets/100451944/f8471a3d-9e3b-44d6-a4b7-4e868b9f3083">

That's it. Now as you run the flow chart in frontend, VS Code will steal focus to let you debug.

4. You can attach both debuggers (RQ Watch and RQ Worker) at the same. You will see a dropdown to select which one you want to step through.
<img width="292" alt="Screenshot 2023-06-15 at 11 32 15 PM" src="https://github.com/flojoy-io/studio/assets/100451944/6a5d8982-a562-490c-8fd8-930fa2a8ad11">


### How was this change tested?
Tested with the default example app in local machine following the above steps.
