### PR TITLE
fix flojoy python library version and rq worker debugging setup

### DIFF
--- a/PYTHON/rq_worker.py
+++ b/PYTHON/rq_worker.py
@@ -11,32 +11,34 @@ from dao.redis_dao import RedisDao
 
 sys.path.append(os.path.abspath(os.getcwd()))
 
+DEBUG_PORT_WORKER = 5678
+DEBUG_PORT_WATCH = 5679
 
-DEFAULT_PORT = 5679
 
-
-def debugger():
-    print("Checking whether to run debugger for rq watch")
+def debugger(port: int, worker_name: str):
     if os.environ.get("DEBUG", None) == "True":
-        port = int(os.environ.get("DEBUG_PORT", DEFAULT_PORT))
         try:
             endpoint = debugpy.listen(port)
-            print(f"Started debugger for rq watch on {endpoint}")
+            print(f"Started debug server for rq:worker:{worker_name} on {endpoint}")
             is_wait = os.environ.get("DEBUG_WAIT", False) == "True"
             if is_wait:
-                print(f"Waiting for debugger for rq watch to attach on port: {port}")
+                print(
+                    f"Waiting on debugger for rq:worker:{worker_name} to attach on port: {port}"
+                )
                 debugpy.wait_for_client()
         except Exception:
-            print("Failed to start debugging for rq watch or its already running")
+            print(
+                f"Failed to start debug server for rq:worker:{worker_name} or its already running"
+            )
     else:
-        print("Debugging for rq watch is off")
-
-
-debugger()
+        print(f"Debugging for rq:worker:{worker_name} is disabled")
 
 
 if __name__ == "__main__":
     worker_name = sys.argv[1]
+    debugger(
+        DEBUG_PORT_WORKER if worker_name == "flojoy" else DEBUG_PORT_WATCH, worker_name
+    )
     queue = Queue(worker_name, connection=RedisDao().r)
-    worker = Worker([queue], connection=RedisDao().r, name=worker_name)
+    worker = Worker([queue], connection=RedisDao().r)
     worker.work()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ channels==4.0.0
 daphne==4.0.0
 Django==4.1.2
 django-cors-headers==3.13.0
-flojoy==0.1.4.dev6
+flojoy==0.1.4.dev7
 matplotlib==3.5.2
 networkx==2.8.4
 numpy==1.23.0


### PR DESCRIPTION
- Fix flojoy python library version
- Fix rq worker debugging setup. In some previous commit the code was changed which made both rq workers trying to open debugger on the same port which fails.