### PR TITLE
Make node label editable and handle failed nodes

### DIFF
--- a/captain/models/topology.py
+++ b/captain/models/topology.py
@@ -158,7 +158,7 @@ class Topology:
             self.run_jobs(next_jobs)
 
     def process_job_result(
-        self, job_id: str, job_result: dict[str, Any], success: bool
+        self, job_id: str, job_result: dict[str, Any] | None, success: bool
     ):
         """
         process special instructions to scheduler
@@ -168,6 +168,7 @@ class Topology:
         if not success:
             logger.debug(f"{job_id} job failed")
             self.mark_job_failure(job_id)
+            self.cancelled = True
             return []
 
         logger.debug(f"job id: {job_id}")

--- a/captain/routes/flowchart.py
+++ b/captain/routes/flowchart.py
@@ -65,7 +65,7 @@ signal a job has been finished.
 async def worker_response(
     request: Request,
 ):  # TODO figure out way to use Pydantic model, for now use type Request otherwise does not work????
-    if manager.running_topology is not None and manager.running_topology.is_cancelled():
+    if manager.running_topology is None or manager.running_topology.is_cancelled():
         logger.debug("Flowchart is cancelled, ignoring worker response")
         return Response(status_code=200)
 
@@ -76,6 +76,12 @@ async def worker_response(
 
     # broadcast worker response to frontend
     asyncio.create_task(broadcast_worker_response(manager, request_dict))
+
+    if "FAILED_NODES" in request_dict:
+        job_id = request_dict.get("FAILED_NODES", "")
+        manager.running_topology.process_job_result(
+            job_id=job_id, job_result={}, success=False
+        )
 
     if "NODE_RESULTS" in request_dict:
         job_id: str = request_dict.get("NODE_RESULTS", {}).get("id", None)

--- a/captain/utils/flowchart_utils.py
+++ b/captain/utils/flowchart_utils.py
@@ -10,7 +10,7 @@ from typing import Any, Callable
 from captain.types.flowchart import PostWFC
 from captain.utils.logger import logger
 from subprocess import Popen, PIPE
-import importlib
+import pkg_resources
 from .status_codes import STATUS_CODES
 from flojoy.utils import clear_flojoy_memory
 from captain.types.worker import WorkerJobResponse
@@ -169,7 +169,7 @@ async def prepare_jobs_and_run_fc(request: PostWFC, manager: Manager):
             continue
         for package in node["data"]["pip_dependencies"]:
             try:
-                module = importlib.import_module(package["name"])
+                module = pkg_resources.get_distribution(package['name'])
                 socket_msg["PRE_JOB_OP"][
                     "output"
                 ] = f"Package: {module} is already installed!"

--- a/captain/utils/flowchart_utils.py
+++ b/captain/utils/flowchart_utils.py
@@ -169,7 +169,7 @@ async def prepare_jobs_and_run_fc(request: PostWFC, manager: Manager):
             continue
         for package in node["data"]["pip_dependencies"]:
             try:
-                module = pkg_resources.get_distribution(package['name'])
+                module = pkg_resources.get_distribution(package["name"])
                 socket_msg["PRE_JOB_OP"][
                     "output"
                 ] = f"Package: {module} is already installed!"

--- a/src/feature/common/types/ResultsType.ts
+++ b/src/feature/common/types/ResultsType.ts
@@ -92,7 +92,6 @@ export type Result = {
     data: OverridePlotData;
     layout?: Partial<Layout>;
   };
-  data: DataContainer;
 };
 
 export interface ResultsType {

--- a/src/feature/flow_chart_panel/FlowChartTabView.tsx
+++ b/src/feature/flow_chart_panel/FlowChartTabView.tsx
@@ -17,6 +17,7 @@ import {
   ConnectionLineType,
   EdgeTypes,
   MiniMap,
+  Node,
   NodeDragHandler,
   NodeTypes,
   OnConnect,
@@ -218,7 +219,7 @@ const FlowChartTab = () => {
 
   const selectAllNodesShortcut = () => {
     setNodes((nodes) => {
-      nodes.map((node) => {
+      nodes.forEach((node) => {
         node.selected = true;
       });
     });
@@ -226,7 +227,7 @@ const FlowChartTab = () => {
 
   const deselectAllNodeShortcut = () => {
     setNodes((nodes) => {
-      nodes.map((node) => {
+      nodes.forEach((node) => {
         node.selected = false;
       });
     });
@@ -234,7 +235,7 @@ const FlowChartTab = () => {
 
   const deselectNodeShortcut = () => {
     setNodes((nodes) => {
-      nodes.map((node) => {
+      nodes.forEach((node) => {
         if (selectedNode !== null && node.id === selectedNode.id) {
           node.selected = false;
         }
@@ -314,6 +315,10 @@ const FlowChartTab = () => {
               nodes.filter((n) => n.selected).length > 1 ? null : selectedNode
             }
             unSelectedNodes={unSelectedNodes}
+            nodes={nodes}
+            setNodes={(nodes: Node<ElementsData>[]) => {
+              setNodes(nodes);
+            }}
           />
 
           <FlowChartKeyboardShortcuts />

--- a/src/feature/flow_chart_panel/components/node-edit-menu/NodeEditMenu.tsx
+++ b/src/feature/flow_chart_panel/components/node-edit-menu/NodeEditMenu.tsx
@@ -7,20 +7,20 @@ import { Box } from "@mantine/core";
 type NodeEditMenuProps = {
   selectedNode: Node<ElementsData> | null;
   unSelectedNodes: Node<ElementsData>[] | null; //used in ParamField.tsx for references
+  nodes: Node<ElementsData>[];
+  setNodes: (nodes: Node<ElementsData>[]) => void;
 };
 
 export const NodeEditMenu = ({
   selectedNode,
   unSelectedNodes,
+  nodes,
+  setNodes,
 }: NodeEditMenuProps) => {
   const { isEditMode, setIsEditMode } = useFlowChartState();
 
-  const canEditNode = selectedNode
-    ? Object.keys(selectedNode.data.ctrls).length > 0
-    : false;
-
   const onSelectionChange = () => {
-    if (!selectedNode || !canEditNode) {
+    if (!selectedNode) {
       setIsEditMode(false);
     }
   };
@@ -28,8 +28,13 @@ export const NodeEditMenu = ({
 
   return (
     <Box pos="relative">
-      {selectedNode && canEditNode && isEditMode && (
-        <NodeEditModal node={selectedNode} otherNodes={unSelectedNodes} />
+      {selectedNode && isEditMode && (
+        <NodeEditModal
+          node={selectedNode}
+          otherNodes={unSelectedNodes}
+          nodes={nodes}
+          setNodes={setNodes}
+        />
       )}
     </Box>
   );

--- a/src/feature/flow_chart_panel/components/node-edit-menu/NodeEditModal.tsx
+++ b/src/feature/flow_chart_panel/components/node-edit-menu/NodeEditModal.tsx
@@ -1,12 +1,13 @@
 import { Node } from "reactflow";
 import { ElementsData } from "../../types/CustomNodeProps";
 import ParamField from "./ParamField";
-import { IconPencil, IconX } from "@tabler/icons-react";
+import { IconPencil, IconX, IconCheck } from "@tabler/icons-react";
 import { useFlowChartState } from "@src/hooks/useFlowChartState";
-import { Box, Title, createStyles } from "@mantine/core";
-import { memo, useEffect } from "react";
+import { Box, Title, createStyles, TextInput } from "@mantine/core";
+import { memo, useEffect, useState } from "react";
 import { ParamValueType } from "@feature/common/types/ParamValueType";
 import Draggable from "react-draggable";
+import { notifications } from "@mantine/notifications";
 
 const useStyles = createStyles((theme) => ({
   modal: {
@@ -20,6 +21,23 @@ const useStyles = createStyles((theme) => ({
     backgroundColor: theme.colors.modal[0],
     boxShadow:
       theme.colorScheme === "dark" ? "none" : "0px 0px 8px 0px rgba(0,0,0,0.3)",
+    overflowY: "scroll",
+    "&::-webkit-scrollbar": {
+      width: "8px",
+      backgroundColor: "transparent",
+    },
+    "&::-webkit-scrollbar-track": {
+      backgroundColor: "transparent",
+    },
+    "&:hover": {
+      "&::-webkit-scrollbar-thumb": {
+        backgroundColor:
+          theme.colorScheme === "dark"
+            ? theme.colors.accent1[0]
+            : theme.colors.accent2[2],
+        borderRadius: "4px",
+      },
+    },
   },
   title: {
     fontWeight: 700,
@@ -52,17 +70,64 @@ const useStyles = createStyles((theme) => ({
 type NodeEditModalProps = {
   node: Node<ElementsData>;
   otherNodes: Node<ElementsData>[] | null;
+  nodes: Node<ElementsData>[];
+  setNodes: (nodes: Node<ElementsData>[]) => void;
 };
 
-const NodeEditModal = ({ node, otherNodes }: NodeEditModalProps) => {
+const NodeEditModal = ({
+  node,
+  otherNodes,
+  nodes,
+  setNodes,
+}: NodeEditModalProps) => {
+  const [isTitleEditable, setIsTitleEditable] = useState(false);
+  const [hasParams, setHasParams] = useState(false);
+  const [newTitle, setNewTitle] = useState(node.data.label);
   const { classes } = useStyles();
   const { setIsEditMode, setNodeParamChanged, nodeParamChanged } =
     useFlowChartState();
   const replayNotice = "Replay the script to see your changes take effect";
   //converted from node to Ids here so that it will only do this when the edit menu is opened
   const nodeReferenceOptions =
-    otherNodes?.map((node) => ({ label: node.data.label, value: node.id })) ||
+    otherNodes?.map((node) => ({ label: node.data.label, value: node.id })) ??
     [];
+
+  const handleTitleChange = (value: string) => {
+    setIsTitleEditable(false);
+    if (value === node.data.label) {
+      return;
+    }
+    const isDuplicate = nodes.find(
+      (n) => n.data.label === value && n.data.id !== node.data.id
+    );
+    if (isDuplicate) {
+      notifications.show({
+        id: "label-change-error",
+        color: "red",
+        title: "Cannot change label",
+        message: `There is another node with the same label: ${value}`,
+        autoClose: 5000,
+        withCloseButton: true,
+      });
+      return;
+    }
+    const updatedNodes = nodes?.map((n) => {
+      if (n.data.id === node.data.id) {
+        return { ...n, data: { ...n.data, label: value } };
+      }
+      return n;
+    });
+    setNodes(updatedNodes);
+  };
+
+  useEffect(() => {
+    if (Object.keys(node.data.ctrls).length) {
+      setHasParams(true);
+    } else {
+      setHasParams(false);
+    }
+    setNewTitle(node.data.label);
+  }, [node.data.id]);
 
   useEffect(() => {
     if (nodeParamChanged === undefined) {
@@ -73,7 +138,7 @@ const NodeEditModal = ({ node, otherNodes }: NodeEditModalProps) => {
   }, [node.data.ctrls]);
 
   return (
-    <Draggable bounds="main" cancel="#undrag">
+    <Draggable bounds="main" cancel="#undrag,#title_input">
       <Box className={classes.modal}>
         <Box
           onClick={() => setIsEditMode(false)}
@@ -84,31 +149,69 @@ const NodeEditModal = ({ node, otherNodes }: NodeEditModalProps) => {
         <Box p="0px 16px 24px 16px">
           <div key={node.id}>
             <Box className={classes.titleContainer}>
-              <Title size="h4" className={classes.title}>
-                {node.data.func.toUpperCase()}
-              </Title>
-              <IconPencil
-                size={18}
-                style={{ marginLeft: "16px", marginBottom: "4px" }}
-              />
+              {isTitleEditable ? (
+                <>
+                  <TextInput
+                    id={"title_input"}
+                    value={newTitle}
+                    onChange={(e) => setNewTitle(e.target.value)}
+                  />
+                  <IconCheck
+                    onClick={() => {
+                      handleTitleChange(newTitle);
+                    }}
+                    size={28}
+                    style={{
+                      marginLeft: "8px",
+                      marginBottom: "4px",
+                      cursor: "pointer",
+                    }}
+                  />
+                </>
+              ) : (
+                <>
+                  <Title size="h4" className={classes.title}>
+                    {node.data.label}
+                  </Title>
+                  <IconPencil
+                    onClick={() => {
+                      setIsTitleEditable(true);
+                    }}
+                    size={18}
+                    style={{
+                      marginLeft: "16px",
+                      marginBottom: "4px",
+                      cursor: "pointer",
+                    }}
+                  />
+                </>
+              )}
             </Box>
-            {Object.entries(node.data.ctrls).map(([name, param]) => (
-              <div key={node.id + name} id="undrag">
-                <p className={classes.paramName}>{`${name.toUpperCase()}:`}</p>
-                <ParamField
-                  nodeId={node.id}
-                  nodeCtrls={node.data.ctrls[name]}
-                  type={param.type as ParamValueType}
-                  value={node.data.ctrls[name].value}
-                  options={param.options}
-                  nodeReferenceOptions={nodeReferenceOptions}
-                />
-              </div>
-            ))}
-            {nodeParamChanged && (
-              <div className={classes.replayScriptNotice}>
-                <i>{replayNotice}</i>
-              </div>
+            {hasParams ? (
+              <>
+                {Object.entries(node.data.ctrls).map(([name, param]) => (
+                  <div key={node.id + name} id="undrag">
+                    <p
+                      className={classes.paramName}
+                    >{`${name.toUpperCase()}:`}</p>
+                    <ParamField
+                      nodeId={node.id}
+                      nodeCtrls={node.data.ctrls[name]}
+                      type={param.type as ParamValueType}
+                      value={node.data.ctrls[name].value}
+                      options={param.options}
+                      nodeReferenceOptions={nodeReferenceOptions}
+                    />
+                  </div>
+                ))}
+                {nodeParamChanged && (
+                  <div className={classes.replayScriptNotice}>
+                    <i>{replayNotice}</i>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div>This node takes no parameters</div>
             )}
           </div>
         </Box>


### PR DESCRIPTION
### Changes:
- Added functionality to make the label of a node editable through the NodeEditMenu.
- Implemented a scrollable parameter sidebar to address the overflow issue when there are more than 4 parameters.
- Implemented cancellation of the flowchart when a node fails.