### PR TITLE
Fix electron build + add option for wayland flags

### DIFF
--- a/src/__tests__/feature/flow_chart_panel/components/NodeWrapper.test.tsx
+++ b/src/__tests__/feature/flow_chart_panel/components/NodeWrapper.test.tsx
@@ -15,6 +15,7 @@ const elementData: ElementsData = {
       param: "first_param",
       value: "10",
       type: "int",
+      desc: null,
     },
   },
   func: "Rand",

--- a/src/__tests__/feature/flow_chart_panel/components/SidebarCustomContent.test.tsx
+++ b/src/__tests__/feature/flow_chart_panel/components/SidebarCustomContent.test.tsx
@@ -1,33 +1,13 @@
 import { renderWithTheme } from "@src/__tests__/__utils__/utils";
 import SidebarCustomContent from "@src/feature/flow_chart_panel/components/SidebarCustomContent";
-import { fireEvent } from "@testing-library/react";
-
-const onAddNode = jest.fn();
-const endNodeElem = {
-  type: "TERMINATOR",
-  key: "END",
-  children: null,
-  name: "END",
-};
 
 describe("SidebarCustomContent component", () => {
   it("renders correctly with default props", () => {
     const { container, getByTestId } = renderWithTheme(
-      <SidebarCustomContent onAddNode={onAddNode} nodesManifest={[]} />
+      <SidebarCustomContent />
     );
     const reqNodeBtn = getByTestId("request-node-btn");
     expect(reqNodeBtn).toBeInTheDocument();
     expect(container).toMatchSnapshot();
-  });
-  it("Fires onAddNode function upon clicking on End node button.", () => {
-    const { getByTestId } = renderWithTheme(
-      <SidebarCustomContent
-        onAddNode={onAddNode}
-        nodesManifest={[endNodeElem]}
-      />
-    );
-    const endNodeBtn = getByTestId("end-node-btn");
-    fireEvent.click(endNodeBtn);
-    expect(onAddNode).toBeCalledWith(endNodeElem);
   });
 });

--- a/src/__tests__/feature/flow_chart_panel/components/custom-nodes/ConditionalNode.test.tsx
+++ b/src/__tests__/feature/flow_chart_panel/components/custom-nodes/ConditionalNode.test.tsx
@@ -17,6 +17,7 @@ const props: CustomNodeProps = {
         id: "test",
         name: "test",
         type: "test",
+        desc: null,
       },
     ],
   },

--- a/src/__tests__/feature/flow_chart_panel/components/custom-nodes/SimulationNode.test.tsx
+++ b/src/__tests__/feature/flow_chart_panel/components/custom-nodes/SimulationNode.test.tsx
@@ -17,6 +17,7 @@ const props: CustomNodeProps = {
         id: "test",
         name: "test",
         type: "test",
+        desc: null,
       },
     ],
   },

--- a/src/__tests__/feature/flow_chart_panel/components/custom-nodes/VisorNode.test.tsx
+++ b/src/__tests__/feature/flow_chart_panel/components/custom-nodes/VisorNode.test.tsx
@@ -17,6 +17,7 @@ const props: CustomNodeProps = {
         id: "test",
         name: "test",
         type: "test",
+        desc: null,
       },
     ],
   },

--- a/src/__tests__/feature/flow_chart_panel/views/NodeModal.test.tsx
+++ b/src/__tests__/feature/flow_chart_panel/views/NodeModal.test.tsx
@@ -11,11 +11,6 @@ const props: NodeModalProps = {
     cmd: "test",
     id: "test-1",
     result: {
-      data: {
-        type: "ordered_pair",
-        x: [],
-        y: [],
-      },
       default_fig: {
         data: [],
       },

--- a/src/data/RECIPES.ts
+++ b/src/data/RECIPES.ts
@@ -1,4 +1,7 @@
-export const NOISY_SINE = {
+import { ElementsData } from "@src/feature/flow_chart_panel/types/CustomNodeProps";
+import { ReactFlowJsonObject } from "reactflow";
+
+export const NOISY_SINE: ReactFlowJsonObject<ElementsData> = {
   nodes: [
     {
       width: 208,

--- a/src/feature/flow_chart_panel/types/CustomNodeProps.ts
+++ b/src/feature/flow_chart_panel/types/CustomNodeProps.ts
@@ -26,6 +26,7 @@ export type ElementsData = {
     name: string;
     id: string;
     type: string;
+    multiple: boolean;
     desc: string | null;
   }>;
   outputs?: Array<{

--- a/src/feature/flow_chart_panel/views/ControlBar.tsx
+++ b/src/feature/flow_chart_panel/views/ControlBar.tsx
@@ -38,7 +38,6 @@ import useKeyboardShortcut from "@src/hooks/useKeyboardShortcut";
 import Dropdown from "@src/feature/common/Dropdown";
 import { useControlsState } from "@src/hooks/useControlsState";
 import { ResultsType } from "@src/feature/common/types/ResultsType";
-import S3KeyModal from "./S3KeyModal";
 import SaveFlowChartBtn from "./SaveFlowChartBtn";
 
 const useStyles = createStyles((theme) => {

--- a/src/hooks/useFlowChartGraph.ts
+++ b/src/hooks/useFlowChartGraph.ts
@@ -6,8 +6,7 @@ import { Edge, Node, ReactFlowJsonObject } from "reactflow";
 import { NOISY_SINE } from "../data/RECIPES";
 import { nodeSection, NodeElement } from "@src/utils/ManifestLoader";
 
-const initialNodes: Node<ElementsData>[] =
-  NOISY_SINE.nodes as Node<ElementsData>[];
+const initialNodes: Node<ElementsData>[] = NOISY_SINE.nodes;
 const initialEdges: Edge[] = NOISY_SINE.edges;
 
 const nodesAtom = atomWithImmer<Node<ElementsData>[]>(initialNodes);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,13 @@ export default defineConfig(({ command }) => {
               console.log(
                 /* For `.vscode/.debug.script.mjs` */ "[startup] Electron App"
               );
+            } else if (process.env.FLOJOY_USE_WAYLAND) {
+              options.startup([
+                ".",
+                "--no-sandbox",
+                "--enable-features=UseOzonePlatform",
+                "--ozone-platform=wayland",
+              ]);
             } else {
               options.startup();
             }


### PR DESCRIPTION
Changes:
- Fixed build for electron
- Add `--enable-features=UseOzonePlatform` and `--ozone-platform=wayland` to electron command line arguments when the `FLOJOY_USE_WAYLAND` environment variable is set. This fixes blurry rendering on Linux systems running a Wayland session.